### PR TITLE
Fix license fetch when offline

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,8 +4,13 @@ import requests
 
 # Fetch the license text from GitHub
 license_url = "https://raw.githubusercontent.com/openai/whisper/main/LICENSE"
-response = requests.get(license_url)
-license_text = response.text
+try:
+    response = requests.get(license_url, timeout=5)
+    response.raise_for_status()
+    license_text = response.text
+except requests.RequestException:
+    # Fallback text in case the license cannot be retrieved (e.g. no network)
+    license_text = "License text could not be loaded from GitHub."
 
 # Initialize the Whisper model
 whisper = Whisper()


### PR DESCRIPTION
## Summary
- handle network errors fetching the license in `app.py`

## Testing
- `python -m py_compile app.py whisper.py test_data/whisper.py`

------
https://chatgpt.com/codex/tasks/task_e_683fe64bfac4832cb3d26d0d9b3659c8